### PR TITLE
Observações (consulte os commits)

### DIFF
--- a/singleton/src/main/java/com/github/alicefrancener/singleton/domain/ConexaoDB.java
+++ b/singleton/src/main/java/com/github/alicefrancener/singleton/domain/ConexaoDB.java
@@ -40,10 +40,13 @@ public final class ConexaoDB {
     }
 
     /**
-     * Métodos get e set
+     * FIXME
+     * Se há uma única instância de uma classe ConexaoDB, então não faz
+     * sentido permitir a ataulização nem da senha nem do usuário, pois não
+     * haveria nenhum efeito??!!!
+     *
+     * @param senha
      */
-
-
     public void setSenha(String senha) {
         this.senha = senha;
     }

--- a/singleton/src/test/java/com/github/alicefrancener/singleton/domain/ConexaoDBTest.java
+++ b/singleton/src/test/java/com/github/alicefrancener/singleton/domain/ConexaoDBTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class ClasseTest {
+public class ConexaoDBTest {
 
     @Test
     void duasConexoesMesmaInstancia() {

--- a/singleton/src/test/java/com/github/alicefrancener/singleton/domain/ConexaoDBTest.java
+++ b/singleton/src/test/java/com/github/alicefrancener/singleton/domain/ConexaoDBTest.java
@@ -3,16 +3,15 @@ package com.github.alicefrancener.singleton.domain;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 class ConexaoDBTest {
 
     @Test
     void duasConexoesMesmaInstancia() {
         ConexaoDB conexao = ConexaoDB.getInstance();
-        conexao.setSenha("senha123");
-
         ConexaoDB conexao2 = ConexaoDB.getInstance();
-        assertEquals(conexao.getSenha(),conexao2.getSenha());
+        assertSame(conexao, conexao2);
     }
 
 }

--- a/singleton/src/test/java/com/github/alicefrancener/singleton/domain/ConexaoDBTest.java
+++ b/singleton/src/test/java/com/github/alicefrancener/singleton/domain/ConexaoDBTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class ConexaoDBTest {
+class ConexaoDBTest {
 
     @Test
     void duasConexoesMesmaInstancia() {


### PR DESCRIPTION
Duas questões: (a) veja o teste como foi alterado; (b) há uma consideração semântica sobre a classe. Afinal, um Singleton para o qual há métodos set públicos permitem o acesso a uma instância global única, o que deveríamos evitar. 